### PR TITLE
Wire bond Semiconductor die

### DIFF
--- a/circuits/Ohm's Law/index.html
+++ b/circuits/Ohm's Law/index.html
@@ -63,19 +63,22 @@
 			<br>\(\Delta t\) = a period of time [s]
 		</div>
 		<div class='example'>
-			<svg viewBox="0,0,300,135" class="side-graphics" style="position: relative; top: 150px; left: 100%;margin-top: -250px;">
+			<svg viewBox="0,0,846,381" class="side-graphics" style="position: relative; top: 150px; left: 100%; margin-top: -250px;">
 				<g>
-					<path style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:0.35433070999999999;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;"
-					 d="M 8.8582677,15.944883 C 8.8582677,10.629922 12.401575,5.3149617 17.716535,5.3149617 C 23.031495,5.3149617 26.574803,10.629922 26.574803,15.944883 C 26.574803,21.259844 26.574803,35.433072 26.574803,35.433072 L 7.0866142,35.433072 L 7.0866142,32.775592 L 8.8582677,32.775592 C 8.8582677,32.775592 8.8582677,21.259844 8.8582677,15.944883 z"
+					<path style="fill: #ffffff; stroke: #000000; stroke-width: 1;"
+					 d="M 25,45 c 0,-40 50,-40 50,0 L 75,100 l -55,0 l 0,-8 l 5,0 z"
 					/>
-					<path style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:0.35433070999999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;"
-					 d="M 12.401575,134.64567 L 14.173228,134.64567 L 14.173228,42.519686 L 15.059055,42.519686 L 15.059055,38.976379 L 14.173228,38.976379 L 14.173228,32.775592 L 12.401575,31.003938 L 12.401575,28.346458 L 15.944882,28.346458 L 15.944882,26.574804 L 12.401575,24.803151 L 12.401575,23.031497 L 10.629921,23.031497 L 10.629921,31.889765 L 12.401575,33.661418 L 12.401575,38.976379 L 11.515748,38.976379 L 11.515748,42.519686 L 12.401575,42.519686 L 12.401575,134.64567 z"
+					<path style="fill: #ffffff; stroke: #000000; stroke-width: 1;"
+					 d="M 35,380 l 5,0 l 0,-260 l 2,0 l 0,-10 l -2,0 l 0,-18 l -5,-5 l 0,-5 l 10,0 l 0,-5 l -10,-7 l 0,-5 l -5,0 l 0,25 l 5,5 l 0,15 l -2,0 l 0,10 l 2,0 l 0,260 z"
 					/>
-					<path style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:0.35433071999999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;"
-					 d="M 21.259843,127.55906 L 23.031496,127.55906 L 23.031496,42.519686 L 23.917323,42.519686 L 23.917323,38.976379 L 23.031496,38.976379 L 23.031496,33.661418 L 24.80315,31.889765 L 24.80315,26.574804 L 23.031496,26.574804 L 23.031496,23.031497 L 15.059055,23.031497 L 15.059055,24.803151 L 21.259843,28.346458 L 23.031496,28.346458 L 23.031496,31.003938 L 21.259843,32.775592 L 21.259843,38.976379 L 20.374016,38.976379 L 20.374016,42.519686 L 21.259843,42.519686 L 21.259843,127.55906 z"
+					<path style="fill: #ffffff; stroke: #000000; stroke-width: 1;"
+					 d="M 60,360 l 5,0 l 0,-240 l 2,0 l 0,-10 l -2,0 l 0,-15 l 5,-5 l 0,-15 l -5,0 l 0,-10 l -23,0 l 0,5 l 18,12 l 5,0 l 0,5 l -5,5 l 0,18 l -2,0 l 0,10 l 2,0 l 0,240 z"
 					/>
-					<path style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.35433071;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
-					 d="M 11.515748,23.031497 C 12.401575,21.259844 15.059055,21.259844 15.944882,23.031497 C 16.830709,24.803151 19.488189,24.803151 20.374016,23.031497"
+					<path style="fill: none; stroke: #000000; stroke-width: 1;"
+					 d="M 32,65 c 7,-8 13,-8 20,0"
+					/>
+					<path style="fill: none; stroke: #000000; stroke-width: 1;"
+					 d="M 45,65 c 2,5 10,5 12,0"
 					/>
 				</g>
 			</svg>


### PR DESCRIPTION
fix side-graphic SVG where LED example

Wire bond Semiconductor die

diff for the side-graphic :

![diff for the side-graphic](https://user-images.githubusercontent.com/8434901/40703047-920a5892-6416-11e8-86f7-24e13485dcbb.png)

here is another graphic on wikimedia :
https://upload.wikimedia.org/wikipedia/commons/f/f9/LED%2C_5mm%2C_green_%28en%29.svg

found in this page :
https://en.wikipedia.org/wiki/Light-emitting_diode
