### PR TITLE
Clean up math notation in motion/vectors-and-scalars

### DIFF
--- a/physics/notes/motion/3-vectors-and-scalors/index.html
+++ b/physics/notes/motion/3-vectors-and-scalors/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 
 <head>
@@ -152,8 +152,8 @@
 				<text x="205" y="105" fill="black" text-anchor="middle" alignment-baseline="middle">opp</text>
 				<text x="46" y="141" fill="black" text-anchor="middle" alignment-baseline="middle">θ</text>
 			</svg>
-			$$ sin \theta = \frac{opp}{hyp} $$ $$ cos \theta = \frac{adj}{hyp} $$ $$ tan \theta = \frac{opp}{adj} $$
-			<br> $$ (hyp)sin \theta = opp \quad (hyp)cos \theta = adj$$
+			$$ \sin \theta = \frac{\mathrm{opp}}{\mathrm{hyp}} $$ $$ \cos \theta = \frac{\mathrm{adj}}{\mathrm{hyp}} $$ $$ \tan \theta = \frac{\mathrm{opp}}{\mathrm{adj}} $$
+			<br> $$ (\mathrm{hyp}) \sin \theta = \mathrm{opp} \quad (\mathrm{hyp}) \cos \theta = \mathrm{adj} $$
 
 			<br>
 			<br>
@@ -171,7 +171,7 @@
 				<text x="205" y="55" fill="black" text-anchor="middle" alignment-baseline="middle">Vy</text>
 				<text x="46" y="91" fill="black" text-anchor="middle" alignment-baseline="middle">θ</text>
 			</svg>
-			<br>$$ v_{x} = (v)cos \theta$$ $$ v_{y} = (v)sin \theta$$
+			<br>$$ v_{x} = (v) \cos \theta$$ $$ v_{y} = (v) \sin \theta $$
 			<br>
 			<br>
 			<p>For displacement the equations are the same</p>
@@ -187,7 +187,7 @@
 				<text x="205" y="55" fill="black" text-anchor="middle" alignment-baseline="middle">y</text>
 				<text x="46" y="91" fill="black" text-anchor="middle" alignment-baseline="middle">θ</text>
 			</svg>
-			<br>$$ x = (d)cos \theta$$ $$ y = (d)sin \theta$$
+			<br>$$ x = (d) \cos \theta $$ $$ y = (d) \sin \theta $$
 			<br>
 			<br>
 			<br>
@@ -202,7 +202,7 @@
 				it moving in only the vertical direction?
 				<details>
 					<summary>solution</summary>
-					$$ v_{y} = (v)sin \theta$$ $$ v_{y} = (250 \, \tfrac{m}{s})sin(14 \degree)$$ $$ v_{y} = 61 \, \tfrac{m}{s}$$
+					$$ v_{y} = (v) \sin \theta $$ $$ v_{y} = (250 \, \tfrac{m}{s}) \sin(14 \degree) $$ $$ v_{y} = 61 \, \tfrac{m}{s} $$
 				</details>
 			</div>
 			<div class='example'>
@@ -212,14 +212,14 @@
 				<details>
 					<summary>solution</summary>
 					<p> northwest means 45 degrees </p>
-					$$ x = (v)cos \theta$$ $$ x = (75 \, m)cos(45 \degree)$$ $$ x = 53m$$
+					$$ x = (v) \cos \theta $$ $$ x = (75 \, m) \cos(45 \degree) $$ $$ x = 53m $$
 				</details>
 			</div>
 			<div class='example'>
 				<b>Example:</b> You walk 3 miles north and then 4 miles west. How far away are you from your starting location?
 				<details>
 					<summary>solution</summary>
-					$$a^{2}+b^{2} = c^{2}$$ $$3^{2}+4^{2} = c^{2}$$ $$25 = c^{2}$$ $$5 \ miles = c$$
+					$$a^{2}+b^{2} = c^{2}$$ $$3^{2}+4^{2} = c^{2}$$ $$25 = c^{2}$$ $$5 \ \mathrm{miles} = c$$
 				</details>
 			</div>
 		</article>


### PR DESCRIPTION
There were a bunch of missing slashes in the LaTeX, plus I put the triangle side names into upright script.

After merging this, please rename the folder above to spell "scalar" with two "a". This is most easily done with the desktop interface.