### PR TITLE
Randomly select students

### DIFF
--- a/physics/lib/roster.js
+++ b/physics/lib/roster.js
@@ -1,0 +1,66 @@
+// Copy and paste from the google classroom
+students = [
+	// Period 1
+	[],
+
+	// Period 2
+	[
+		"Niora Abraham",
+		"Brandon Adreani",
+		"Arielle Ambrose",
+		"Ognjen Antonijevic",
+		"Katherine Babb",
+		"Dakota Bartley",
+		"Alden Baughman",
+		"Daniel Blumkine",
+		"Rhiannon Camarillo",
+		"Chloe Clair",
+		"Jenny Cortez",
+		"Marlise Deyerl",
+		"Mira Dixon",
+		"Nathaniel Drebin",
+		"Luke Fitzmorris",
+		"Eli Hammond",
+		"Haylie Huerta",
+		"Matei Meglic",
+		"Hana Morshedi",
+		"James Murphy",
+		"Reuben Noorvash",
+		"Gabriel Pizarro",
+		"Ava Qureshi",
+		"Leo Raksin",
+		"Christopher Rose",
+		"Jonah Saguy",
+		"Joseph Schwartz",
+		"Dylan Shad",
+		"Elizabeth Shepherd",
+		"Ashley Spence",
+		"Lila Tauzin-Fox",
+		"Rolando Torres",
+		"Luchia Torro",
+		"Georgia Turman",
+		"Cole Turner",
+		"Samantha Weinberg",
+		"Ryden Weiss",
+		"Anique Wertheimer",
+		"Alexander Wolff",
+		"Leo Wou",
+	],
+
+	// Period 3
+	[],
+
+	// Period 4
+	[],
+
+	// Period 5
+	[],
+
+	// Period 6
+	[],
+]
+
+function selectStudent(period) {
+	let studentIdx = Math.floor(Math.random() * students.length);
+	return students[period-1][studentIdx];
+}

--- a/physics/notes/circuits/components/index.html
+++ b/physics/notes/circuits/components/index.html
@@ -1002,6 +1002,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/circuits/electricity/index.html
+++ b/physics/notes/circuits/electricity/index.html
@@ -697,6 +697,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 	<script src='../../../lib/chargeclass.js'></script>
 	<script src="charge7.js"></script>
 	<script src="charge8.js"></script>

--- a/physics/notes/circuits/kirchoff/index.html
+++ b/physics/notes/circuits/kirchoff/index.html
@@ -1404,6 +1404,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/circuits/power/index.html
+++ b/physics/notes/circuits/power/index.html
@@ -417,6 +417,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/electromagnetism/charge/index.html
+++ b/physics/notes/electromagnetism/charge/index.html
@@ -471,6 +471,7 @@
 		renderMathInElement(document.body);
 	</script>
 	<script src='../../../lib/chargeclass.js'></script>
+	<script src="../../../lib/roster.js"></script>
 	<script src="charge1.js"></script>
 	<script src="charge2.js"></script>
 	<script src="charge5.js"></script>

--- a/physics/notes/electromagnetism/electrostatics/index.html
+++ b/physics/notes/electromagnetism/electrostatics/index.html
@@ -1085,6 +1085,7 @@
 		renderMathInElement(document.body);
 	</script>
 	<script src='../../../lib/chargeclass.js'></script>
+	<script src="../../../lib/roster.js"></script>
 	<script src="charge0.js"></script>
 	<script src="charge3.js"></script>
 </body>

--- a/physics/notes/electromagnetism/magnetism/index.html
+++ b/physics/notes/electromagnetism/magnetism/index.html
@@ -1961,6 +1961,7 @@
 		renderMathInElement(document.body);
 	</script>
 	<script src='../../../lib/chargeclass.js'></script>
+	<script src="../../../lib/roster.js"></script>
 	<script src="charge15.js"></script>
 
 	<!-- <script defer src='https://cdnjs.cloudflare.com/ajax/libs/three.js/98/three.min.js'></script>

--- a/physics/notes/electromagnetism/potential/index.html
+++ b/physics/notes/electromagnetism/potential/index.html
@@ -443,6 +443,7 @@
 		renderMathInElement(document.body);
 	</script>
 	<script defer src='../../../lib/chargeclass.js'></script>
+	<script src="../../../lib/roster.js"></script>
 	<script defer src="charge5.js"></script>
 	<!-- <script defer src="charge6.js"></script>
 	<script defer src="charge7.js"></script> -->

--- a/physics/notes/energy/conservation/index.html
+++ b/physics/notes/energy/conservation/index.html
@@ -675,6 +675,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/energy/energy/index.html
+++ b/physics/notes/energy/energy/index.html
@@ -1002,7 +1002,7 @@
     <script>
         renderMathInElement(document.body);
     </script>
-
+    <script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/energy/thermo/index.html
+++ b/physics/notes/energy/thermo/index.html
@@ -1044,6 +1044,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/force/forces/index.html
+++ b/physics/notes/force/forces/index.html
@@ -1488,6 +1488,7 @@
   <script>
     renderMathInElement(document.body);
   </script>
+  <script src="../../../lib/roster.js"></script>
   <script src="wasd.js"></script>
 </body>
 

--- a/physics/notes/force/friction/index.html
+++ b/physics/notes/force/friction/index.html
@@ -1620,6 +1620,7 @@
     </footer>
 
     <script src='../../../lib/matter.min.js'></script>
+    <script src="../../../lib/roster.js"></script>
     <script src='../../../lib/randomColor.min.js'></script>
     <!-- <script src="friction(Matter.js).js"></script> -->
     <script src="glassSlide(Matter.js).js"></script>

--- a/physics/notes/force/laws/index.html
+++ b/physics/notes/force/laws/index.html
@@ -518,6 +518,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 	<script src="wasd.js"></script>
 	<!-- <script src='../../../lib/matter.min.js'></script> -->
 	<!-- <script src="matterforce.js"></script> -->

--- a/physics/notes/gravity/circular/index.html
+++ b/physics/notes/gravity/circular/index.html
@@ -743,6 +743,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 	<script src='../../../lib/randomColor.min.js'></script>
 	<script src='../../../lib/gravityClass.js'></script>
 	<script src="grav1.js"></script>

--- a/physics/notes/gravity/gravitation/index.html
+++ b/physics/notes/gravity/gravitation/index.html
@@ -1806,6 +1806,7 @@
     <script>
         renderMathInElement(document.body);
     </script>
+    <script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/gravity/stars/index.html
+++ b/physics/notes/gravity/stars/index.html
@@ -67,6 +67,7 @@
     <script>
         renderMathInElement(document.body);
     </script>
+    <script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/momentum/impulse/index.html
+++ b/physics/notes/momentum/impulse/index.html
@@ -228,6 +228,7 @@
   <script>
     renderMathInElement(document.body);
   </script>
+  <script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/momentum/momentum/index.html
+++ b/physics/notes/momentum/momentum/index.html
@@ -317,6 +317,7 @@
     <script src='../../../lib/matter.min.js'></script>
     <script src="newtonsCradle.js"></script>
     <script src='../../../lib/randomColor.min.js'></script>
+    <script src="../../../lib/roster.js"></script>
     <script src="collisionDemo(Matter.js).js"></script>
     <script src="collisionDemo2(Matter.js).js"></script>
     <script src="collisionEx1(Matter.js).js"></script>

--- a/physics/notes/motion/challenge1/index.html
+++ b/physics/notes/motion/challenge1/index.html
@@ -40,7 +40,8 @@
         <button id="clear1" onclick='settings.clear()'>clear</button>
 	<footer>
 		<a href="../../../">Back</a>
-	</footer>	
+	</footer>
+    <script src="../../../lib/roster.js"></script>
     <script src="fire.js"></script>
 </body>
 

--- a/physics/notes/motion/challenge2/index.html
+++ b/physics/notes/motion/challenge2/index.html
@@ -42,7 +42,8 @@
         <button id="clear1" onclick='settings.clear()'>clear</button>
 	<footer>
 		<a href="../../../">Back</a>
-	</footer>	
+	</footer>
+    <script src="../../../lib/roster.js"></script>
     <script src="fire.js"></script>
 </body>
 

--- a/physics/notes/motion/kinematics/index.html
+++ b/physics/notes/motion/kinematics/index.html
@@ -1860,6 +1860,7 @@ https://vuejs.org/v2/guide/components.html
 	</script>
 
 	<script src="tanks.js"></script>
+	<script src="../../../lib/roster.js"></script>
 	<!-- <script src='../../../lib/matter.min.js'></script> -->
 	<!-- <script src="2dMotion(Matter.js).js"></script> -->
 	<script src="../../../lib/vue.min.js"></script>

--- a/physics/notes/motion/motion/index.html
+++ b/physics/notes/motion/motion/index.html
@@ -802,6 +802,7 @@
 		
 	<script src="../../../lib/katex/katex.min.js"></script>
 	<script src="../../../lib/katex/contrib/auto-render.min.js"></script>
+	<script src="../../../lib/roster.js"></script>
 	<script>
 		renderMathInElement(document.body);
 		graphEquations("0.5");

--- a/physics/notes/relativity/general/index.html
+++ b/physics/notes/relativity/general/index.html
@@ -900,6 +900,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/relativity/special/index.html
+++ b/physics/notes/relativity/special/index.html
@@ -1644,6 +1644,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 	<script src="solver.js"></script>
 	<script src="train.js"></script>
 </body>

--- a/physics/notes/review/science/index.html
+++ b/physics/notes/review/science/index.html
@@ -175,6 +175,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/review/solving/index.html
+++ b/physics/notes/review/solving/index.html
@@ -152,9 +152,10 @@
 		<a href="../../../">Back</a>
 	</footer>
 
-		<script>
-			renderMathInElement(document.body);
-		</script>
+	<script>
+		renderMathInElement(document.body);
+	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/review/units/index.html
+++ b/physics/notes/review/units/index.html
@@ -466,6 +466,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/review/vectors/index.html
+++ b/physics/notes/review/vectors/index.html
@@ -672,7 +672,7 @@
 		<a href="../../../">Back</a>
 	</footer>
 
-
+	<script src="../../../lib/roster.js"></script>
 	<script src="vectorDiagram.js"></script>
 	<script>
 		renderMathInElement(document.body);

--- a/physics/notes/waves/light/index.html
+++ b/physics/notes/waves/light/index.html
@@ -1772,6 +1772,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 	<!-- <script src='../../../lib/chargeclass.js'></script> -->
 	<!-- <script src="chargeWave.js"></script> -->
 

--- a/physics/notes/waves/quantum/index.html
+++ b/physics/notes/waves/quantum/index.html
@@ -2478,6 +2478,7 @@
   <script>
     renderMathInElement(document.body);
   </script>
+  <script src="../../../lib/roster.js"></script>
   <script src="doubleSlit.js"></script>
 </body>
 

--- a/physics/notes/waves/waveproperties/index.html
+++ b/physics/notes/waves/waveproperties/index.html
@@ -964,6 +964,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 </body>
 
 </html>

--- a/physics/notes/waves/waves/index.html
+++ b/physics/notes/waves/waves/index.html
@@ -1587,6 +1587,7 @@
 	<script>
 		renderMathInElement(document.body);
 	</script>
+	<script src="../../../lib/roster.js"></script>
 	<script src='../../../lib/matter.min.js'></script>
 	<script src="wave.js "></script>
 	<script src="sound.js "></script>


### PR DESCRIPTION
Adds support for randomly selecting a student from the class roster for each period. This is carried out through the javascript console as shown in the image below. The function takes the class period as a parameter and returns a random student from the class. It would be available on all physics pages. 

Note: I was only able to fill out the roster for period 2 as I do not have access to other periods.

![Screen Shot 2021-03-11 at 10 52 58 AM](https://user-images.githubusercontent.com/52867365/110838997-f474e800-8257-11eb-8a43-cee4e8018f42.png)
